### PR TITLE
V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,131 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* The ability to have duplicate supported languages from formatters, which makes
+  adding new formatters even safer/easier.
+* This changelog :smile:
+* The `fmt-onsave` option, to disable formatting on-save (on by default).
+* A new `fmt list` command, which prints the supported formatters (and their
+  on/off status) to Micro's log in a pretty table.
+* Any output from the formatter is printed to Micro's log for easier debugging.
+* `goimports` formatter for alternative `Go` support
+* `htmlbeautifier` formatter for `HTML` support
+* `coffee-fmt` formatter for `CoffeeScript` support
+* `cljfmt` formatter for `Clojure` support
+* `elm-format` formatter for `Elm` support
+* `clang-format` formatter for alternative `C`, `C++`, and `C#` support
+* `pug-beautifier-cli` formatter for `Pug` (previously `Jade`) support
+* `latexindent.pl` formatter for `LaTeX` support
+* `CSScomb` formatter for alternative `CSS` support
+* `marko-prettyprint` formatter for `Marko` support
+* `ocp-indent` formatter for `OCaml` support
+* `align-yaml` formatter for `YAML` support
+* `perltidy` formatter for `Perl` support
+* `stylish-haskell` formatter for `Haskell` support
+* `puppet-lint` formatter for `Puppet` support
+* `js-beautify` formatter for alternative `Javascript` support
+* `autopep8` formatter for alternative `Python` support
+* Some more info to `CONTRIBUTING.md`
+
+### Changed
+
+* The execution of the actual command, from Lua's `io.popen()`, to Micro's
+  `JobStart()`, which should improve cross-platform support.
+* The `fmt` command now runs the formatter on the current file.
+* Applied as many [luacheck](https://github.com/mpeterv/luacheck)
+  recommendations as possible, aka change stuff to `local`
+* Formatted all the markdown files with the Prettier formatter
+
+## [1.3.0] - 2017-11-11
+
+### Added
+
+* The full command to Micro's log.
+* Users settings in the formatter arguments, where possible.
+* Python support via the `yapf` formatter.
+* PHP support via the `php-cs-fixer` formatter.
+* A link to `CONTRIBUTING.md` in the pull request template.
+* A `.gitignore` to hide a simple script I use for testing.
+* All the languages supported by `uncrustify`, and its `defaults.cfg` config
+  file.
+
+### Changed
+
+* The "how to add a formatter" comments got moved from the code to
+  [CONTRIBUTING.md](./CONTRIBUTING.md)
+* To using the `CurView()` passed from onSave instead of manually calling
+  `CurView()`
+* `fmt.lua` formatted with luafmt.
+* The name of Crystal's formatter in the README.
+* Capitalized the languages in the README.
+
+### Fixed
+
+* The `if` check to see if the current settings match the ones used by the fmt
+  args.
+
+### Removed
+
+* The redundant psudo-contributing guide in the pull request template.
+
+## [1.2.1] - 2017-11-09
+
+### Added
+
+* The fact that markdown works with Prettier to the README.
+* A literal detection fallback function for when Micro returns `Unknown`
+
+## [1.2.0] - 2017-11-07
+
+### Added
+
+* Markdown to Prettier's file-type support.
+
+## [1.1.1] - 2017-11-07
+
+### Added
+
+* Pull request template for Github.
+* Issue template for Github.
+
+### Fixed
+
+* Crystal actually uses the correct command now..
+
+## [1.1.0] - 2017-11-07
+
+### Added
+
+* Crystal formatting.
+
+### Changed
+
+* Flipped the table to hopefully look better.
+
+## [1.0.1] - 2017-11-07
+
+### Fixed
+
+* Rubocop
+* Luafmt
+
+## 1.0.0 - 2017-11-06
+
+First release
+
+[unreleased]: https://github.com/sum01/fmt-micro/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/sum01/fmt-micro/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/sum01/fmt-micro/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/sum01/fmt-micro/compare/v1.1.1...v1.2.0
+[1.1.1]: https://github.com/sum01/fmt-micro/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/sum01/fmt-micro/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/sum01/fmt-micro/compare/v1.0.0...v1.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,37 @@
 # Contributing
-Everything below assumes you're using [the Micro text-editor](https://github.com/zyedidia/micro) and this `fmt` plugin...
 
-**Tooling for contributions:**  
-- Use the [editorconfig](http://editorconfig.org/) plugin to keep everything uniform, which can be installed by doing `plugin install editorconfig`
-- Use [luafmt](https://github.com/trixnz/lua-fmt) if you're editing a `.lua` file, which can be enabled with `set luafmt true`
-- Use [prettier](https://github.com/prettier/prettier) if you're editing a `.md` file, which can be enabled with `set prettier true`
+Everything below assumes you're using
+[the Micro text-editor](https://github.com/zyedidia/micro) and this `fmt`
+plugin...
+
+**Tooling for contributions:**
+
+* Use the [editorconfig](http://editorconfig.org/) plugin to keep everything
+  uniform, which can be installed by doing `plugin install editorconfig`
+* Use [luafmt](https://github.com/trixnz/lua-fmt) if you're editing a `.lua`
+  file, which can be enabled with `set luafmt true`
+* Use [prettier](https://github.com/prettier/prettier) if you're editing a `.md`
+  file, which can be enabled with `set prettier true`
 
 ## Git workflow
-First fork the repo, create a branch from `master`, push your changes to your repo, then submit a PR onto `master`.  
-Please don't commit tons of changes in one big commit. Instead, use `git commit -p` to selectively add lines.
+
+First fork the repo, create a branch from `master`, push your changes to your
+repo, then submit a PR onto `master`.\
+Please don't commit tons of changes in one big commit. Instead, use `git commit -p`
+to selectively add lines.
 
 ## Adding another formatter:
-- Do NOT add a formatter for an already supported filetype. There must not be dulplicate keys!
-- Be careful with spaces when using `insert()` to add the formatter. Spaces get added between the command & args, and between args & the file.
-- Using insert: `insert("filetype", "formattercommand", "args")` 
-  - `filetype` should be from `CurView().Buf:FileType()`
-    - If 2+ filetype's are supported, add them as a table (see how `prettier` was done).
-  - `formattercommand` is the literal cli command to run the formatter (sans args)
-  - If no args are needed, pass a `nil` value. Do NOT leave it empty!
-- PS: Alphabetical order doesn't matter in relation to the order of `insert()` commands. The `fmt` command has a sort in it.
+
+* Do NOT add a formatter for an already supported filetype. There must not be
+  dulplicate keys!
+* Be careful with spaces when using `insert()` to add the formatter. Spaces get
+  added between the command & args, and between args & the file.
+* Using insert: `insert("filetype", "formattercommand", "args")`
+  * `filetype` should be from `CurView().Buf:FileType()`
+    * If 2+ filetype's are supported, add them as a table (see how `prettier`
+      was done).
+  * `formattercommand` is the literal cli command to run the formatter (sans
+    args)
+  * If no args are needed, pass a `nil` value. Do NOT leave it empty!
+* PS: Alphabetical order doesn't matter in relation to the order of `insert()`
+  commands. The `fmt` command has a sort in it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Everything below assumes you're using
 [the Micro text-editor](https://github.com/zyedidia/micro) and this `fmt`
-plugin...
+plugin.
 
 **Tooling for contributions:**
 
@@ -22,16 +22,15 @@ to selectively add lines.
 
 ## Adding another formatter:
 
-* Do NOT add a formatter for an already supported filetype. There must not be
-  dulplicate keys!
 * Be careful with spaces when using `insert()` to add the formatter. Spaces get
   added between the command & args, and between args & the file.
 * Using insert: `insert("filetype", "formattercommand", "args")`
   * `filetype` should be from `CurView().Buf:FileType()`
     * If 2+ filetype's are supported, add them as a table (see how `prettier`
       was done).
-  * `formattercommand` is the literal cli command to run the formatter (sans
-    args)
-  * If no args are needed, pass a `nil` value. Do NOT leave it empty!
+    * To see if Micro supports the filetype, run `show filetype`. If the
+      filetype is not known by Micro (displayed as `Unknown`), then use the
+      literal file extension (without the period)
+  * `formattercommand` is the literal command to run the formatter
 * PS: Alphabetical order doesn't matter in relation to the order of `insert()`
-  commands. The `fmt` command has a sort in it.
+  commands. The `fmt list` command has a sort in it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,5 +32,16 @@ to selectively add lines.
       filetype is not known by Micro (displayed as `Unknown`), then use the
       literal file extension (without the period)
   * `formattercommand` is the literal command to run the formatter
+  * `args` can be left empty, like `insert("filetype", "formattercommand")` if
+    there aren't any, or at least any relevant ones.
 * PS: Alphabetical order doesn't matter in relation to the order of `insert()`
   commands. The `fmt list` command has a sort in it.
+
+Note that regardless of how you structure the `insert()` code, the filepath is
+always added to the end of the `args`, if there are any. Also, a space is added
+between the `formattercommand`, `args`, and the filepath.
+
+**Example:**\
+`insert("python", "autopep8", "-i")`\
+turns into the command..\
+`autopep8 -i path/to/filename`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ want to use.
 
 | Formatter                | Language(s)                                                                                     |
 | :----------------------- | :---------------------------------------------------------------------------------------------- |
+| [coffee-fmt]             | `CoffeeScript`                                                                                  |
 | [crystal]                | `Crystal`                                                                                       |
 | [fish_indent]            | `Fish`                                                                                          |
 | **[goimports]**, [gofmt] | `Go`                                                                                            |
@@ -59,6 +60,7 @@ Run `help fmt` to bring up a help file while in Micro.
 
 <!-- Table links to make the table easier to read in source -->
 
+[coffee-fmt]: https://github.com/sterpe/coffee-fmt
 [crystal]: https://github.com/crystal-lang/crystal
 [fish_indent]: https://fishshell.com/docs/current/commands.html#fish_indent
 [gofmt]: https://golang.org/cmd/gofmt/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ want to use.
 
 | Formatter                | Language(s)                                                                                     |
 | :----------------------- | :---------------------------------------------------------------------------------------------- |
+| [clang-format]           | `C`, `C++`, `C#`                                                                                |
 | [cljfmt]                 | `Clojure`                                                                                       |
 | [coffee-fmt]             | `CoffeeScript`                                                                                  |
 | [crystal]                | `Crystal`                                                                                       |
@@ -62,6 +63,7 @@ Run `help fmt` to bring up a help file while in Micro.
 
 <!-- Table links to make the table easier to read in source -->
 
+[clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [cljfmt]: https://github.com/snoe/node-cljfmt
 [coffee-fmt]: https://github.com/sterpe/coffee-fmt
 [crystal]: https://github.com/crystal-lang/crystal

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note that you can also get a list of formatters by running the `fmt` command.
 
 ### Installation
 
-To find your config's path, run `eval messenger:Message(configDir)`.
+To find your config's path, run `eval messenger:Message(configDir)`
 
 1. Open your config's `settings.json`, and add
    `https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json` to

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 This is a multi-language formatting plugin for the
 [Micro text-editor.](https://github.com/zyedidia/micro)
 
-Note that this plugin can only run installed/built-in formatters (such as
-`rustfmt` or `gofmt`).
+This plugin does NOT bundle any formatters, so you must install whichever you
+want to use.
 
 ## Supported formatters
 
 | Formatter                                                                   | Language(s)                                                                                     |
 | :-------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| [crystal tool format](https://github.com/crystal-lang/crystal)              | `Crystal`                                                                                       |
+| [crystal](https://github.com/crystal-lang/crystal)                          | `Crystal`                                                                                       |
 | [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent) | `Fish`                                                                                          |
 | [gofmt](https://golang.org/cmd/gofmt/)                                      | `Go`                                                                                            |
 | [luafmt](https://github.com/trixnz/lua-fmt)                                 | `Lua`                                                                                           |
@@ -26,11 +26,11 @@ Note that you can also get a list of formatters by running the `fmt` command.
 
 ### Installation
 
-1. Open your config's `settings.json` (located in
-   `~/.config/micro/settings.json` on Linux), and add
+To find your config's path, run `eval messenger:Message(configDir)`.
+
+1. Open your config's `settings.json`, and add
    `https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json` to
    `pluginrepos`, like so:
-
 
 ```json
 "pluginrepos": [
@@ -47,6 +47,11 @@ can skip step 1 of the installation.
 
 ### Usage
 
-The formatter will run on-save (if enabled & exists).\
-The only command is `fmt`, which lists all of the supported formatters.\
-Run `help fmt` after installation to bring up a help file while in Micro.
+The formatter will run on-save, unless `fmt-onsave` is false.
+
+**Commands:**
+
+* `fmt` to run the formatter on the current file.
+* `fmt list` to output the supported formatters to Micro's log.
+
+Run `help fmt` to bring up a help file while in Micro.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ want to use.
 
 | Formatter            | Language(s)                                                                                     |
 | :------------------- | :---------------------------------------------------------------------------------------------- |
+| [align-yaml]         | `YAML`                                                                                          |
 | [clang-format]       | `C`, `C++`, `C#`                                                                                |
 | [cljfmt]             | `Clojure`                                                                                       |
 | [coffee-fmt]         | `CoffeeScript`                                                                                  |
@@ -68,6 +69,7 @@ Run `help fmt` to bring up a help file while in Micro.
 
 <!-- Table links to make the table easier to read in source -->
 
+[align-yaml]: https://github.com/jonschlinkert/align-yaml
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [cljfmt]: https://github.com/snoe/node-cljfmt
 [coffee-fmt]: https://github.com/sterpe/coffee-fmt

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ want to use.
 
 ## Supported formatters
 
-| Formatter                                                                   | Language(s)                                                                                     |
-| :-------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| [crystal](https://github.com/crystal-lang/crystal)                          | `Crystal`                                                                                       |
-| [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent) | `Fish`                                                                                          |
-| [gofmt](https://golang.org/cmd/gofmt/)                                      | `Go`                                                                                            |
-| [luafmt](https://github.com/trixnz/lua-fmt)                                 | `Lua`                                                                                           |
-| [rubocop](https://github.com/bbatsov/rubocop)                               | `Ruby`                                                                                          |
-| [rustfmt](https://github.com/rust-lang-nursery/rustfmt)                     | `Rust`                                                                                          |
-| [shfmt](https://github.com/mvdan/sh)                                        | `Shell`                                                                                         |
-| [php-cs-fixer](https://github.com/friendsofphp/PHP-CS-Fixer)                | `PHP`                                                                                           |
-| [prettier](https://github.com/prettier/prettier)                            | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
-| [uncrustify](https://github.com/uncrustify/uncrustify)                      | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
-| [yapf](https://github.com/google/yapf)                                      | `Python`                                                                                        |
+| Formatter                                                                                                   | Language(s)                                                                                     |
+| :---------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| [crystal](https://github.com/crystal-lang/crystal)                                                          | `Crystal`                                                                                       |
+| [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent)                                 | `Fish`                                                                                          |
+| **[goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)**, [gofmt](https://golang.org/cmd/gofmt/) | `Go`                                                                                            |
+| [luafmt](https://github.com/trixnz/lua-fmt)                                                                 | `Lua`                                                                                           |
+| [rubocop](https://github.com/bbatsov/rubocop)                                                               | `Ruby`                                                                                          |
+| [rustfmt](https://github.com/rust-lang-nursery/rustfmt)                                                     | `Rust`                                                                                          |
+| [shfmt](https://github.com/mvdan/sh)                                                                        | `Shell`                                                                                         |
+| [php-cs-fixer](https://github.com/friendsofphp/PHP-CS-Fixer)                                                | `PHP`                                                                                           |
+| [prettier](https://github.com/prettier/prettier)                                                            | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
+| [uncrustify](https://github.com/uncrustify/uncrustify)                                                      | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
+| [yapf](https://github.com/google/yapf)                                                                      | `Python`                                                                                        |
 
 Note that you can also get a list of formatters by running the `fmt` command.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ want to use.
 | [fish_indent]        | `Fish`                                                                                          |
 | [goimports], [gofmt] | `Go`                                                                                            |
 | [htmlbeautifier]     | `HTML`                                                                                          |
+| [latexindent.pl]     | `LaTeX`                                                                                         |
 | [luafmt]             | `Lua`                                                                                           |
 | [pug-beautifier-cli] | `Pug`                                                                                           |
 | [rubocop]            | `Ruby`                                                                                          |
@@ -73,6 +74,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [gofmt]: https://golang.org/cmd/gofmt/
 [goimports]: https://godoc.org/golang.org/x/tools/cmd/goimports
 [htmlbeautifier]: https://github.com/threedaymonk/htmlbeautifier
+[latexindent.pl]: https://github.com/cmhughes/latexindent.pl
 [luafmt]: https://github.com/trixnz/lua-fmt
 [pug-beautifier-cli]: https://github.com/lgaticaq/pug-beautifier-cli
 [rubocop]: https://github.com/bbatsov/rubocop

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ want to use.
 | [luafmt]             | `Lua`                                                                                           |
 | [marko-prettyprint]  | `Marko`                                                                                         |
 | [ocp-indent]         | `OCaml`                                                                                         |
+| [perltidy]           | `Perl`                                                                                          |
 | [pug-beautifier-cli] | `Pug`                                                                                           |
 | [rubocop]            | `Ruby`                                                                                          |
 | [rustfmt]            | `Rust`                                                                                          |
@@ -84,6 +85,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [luafmt]: https://github.com/trixnz/lua-fmt
 [marko-prettyprint]: https://github.com/marko-js/marko-prettyprint
 [ocp-indent]: https://www.typerex.org/ocp-indent.html
+[perltidy]: http://perltidy.sourceforge.net/
 [pug-beautifier-cli]: https://github.com/lgaticaq/pug-beautifier-cli
 [rubocop]: https://github.com/bbatsov/rubocop
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ want to use.
 | [rubocop]            | `Ruby`                                                                                          |
 | [rustfmt]            | `Rust`                                                                                          |
 | [shfmt]              | `Shell`                                                                                         |
+| [stylish-haskell]    | `Haskell`                                                                                       |
 | [php-cs-fixer]       | `PHP`                                                                                           |
 | [prettier]           | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
 | [uncrustify]         | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
@@ -90,6 +91,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [rubocop]: https://github.com/bbatsov/rubocop
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 [shfmt]: https://github.com/mvdan/sh
+[stylish-haskell]: https://github.com/jaspervdj/stylish-haskell
 [php-cs-fixer]: https://github.com/friendsofphp/PHP-CS-Fixer
 [prettier]: https://github.com/prettier/prettier
 [uncrustify]: https://github.com/uncrustify/uncrustify

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ want to use.
 | [goimports], [gofmt] | `Go`                                                                                            |
 | [htmlbeautifier]     | `HTML`                                                                                          |
 | [luafmt]             | `Lua`                                                                                           |
+| [pug-beautifier-cli] | `Pug`                                                                                           |
 | [rubocop]            | `Ruby`                                                                                          |
 | [rustfmt]            | `Rust`                                                                                          |
 | [shfmt]              | `Shell`                                                                                         |
@@ -73,6 +74,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [goimports]: https://godoc.org/golang.org/x/tools/cmd/goimports
 [htmlbeautifier]: https://github.com/threedaymonk/htmlbeautifier
 [luafmt]: https://github.com/trixnz/lua-fmt
+[pug-beautifier-cli]: https://github.com/lgaticaq/pug-beautifier-cli
 [rubocop]: https://github.com/bbatsov/rubocop
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 [shfmt]: https://github.com/mvdan/sh

--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ want to use.
 
 ## Supported formatters
 
-| Formatter                | Language(s)                                                                                     |
-| :----------------------- | :---------------------------------------------------------------------------------------------- |
-| [clang-format]           | `C`, `C++`, `C#`                                                                                |
-| [cljfmt]                 | `Clojure`                                                                                       |
-| [coffee-fmt]             | `CoffeeScript`                                                                                  |
-| [crystal]                | `Crystal`                                                                                       |
-| [elm-format]             | `Elm`                                                                                           |
-| [fish_indent]            | `Fish`                                                                                          |
-| **[goimports]**, [gofmt] | `Go`                                                                                            |
-| [htmlbeautifier]         | `HTML`                                                                                          |
-| [luafmt]                 | `Lua`                                                                                           |
-| [rubocop]                | `Ruby`                                                                                          |
-| [rustfmt]                | `Rust`                                                                                          |
-| [shfmt]                  | `Shell`                                                                                         |
-| [php-cs-fixer]           | `PHP`                                                                                           |
-| [prettier]               | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
-| [uncrustify]             | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
-| [yapf]                   | `Python`                                                                                        |
+| Formatter            | Language(s)                                                                                     |
+| :------------------- | :---------------------------------------------------------------------------------------------- |
+| [clang-format]       | `C`, `C++`, `C#`                                                                                |
+| [cljfmt]             | `Clojure`                                                                                       |
+| [coffee-fmt]         | `CoffeeScript`                                                                                  |
+| [crystal]            | `Crystal`                                                                                       |
+| [elm-format]         | `Elm`                                                                                           |
+| [fish_indent]        | `Fish`                                                                                          |
+| [goimports], [gofmt] | `Go`                                                                                            |
+| [htmlbeautifier]     | `HTML`                                                                                          |
+| [luafmt]             | `Lua`                                                                                           |
+| [rubocop]            | `Ruby`                                                                                          |
+| [rustfmt]            | `Rust`                                                                                          |
+| [shfmt]              | `Shell`                                                                                         |
+| [php-cs-fixer]       | `PHP`                                                                                           |
+| [prettier]           | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
+| [uncrustify]         | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
+| [yapf]               | `Python`                                                                                        |
 
 Note that you can also get a list of formatters by running the `fmt` command.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ want to use.
 | [cljfmt]                 | `Clojure`                                                                                       |
 | [coffee-fmt]             | `CoffeeScript`                                                                                  |
 | [crystal]                | `Crystal`                                                                                       |
+| [elm-format]             | `Elm`                                                                                           |
 | [fish_indent]            | `Fish`                                                                                          |
 | **[goimports]**, [gofmt] | `Go`                                                                                            |
 | [htmlbeautifier]         | `HTML`                                                                                          |
@@ -64,6 +65,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [cljfmt]: https://github.com/snoe/node-cljfmt
 [coffee-fmt]: https://github.com/sterpe/coffee-fmt
 [crystal]: https://github.com/crystal-lang/crystal
+[elm-format]: https://github.com/avh4/elm-format
 [fish_indent]: https://fishshell.com/docs/current/commands.html#fish_indent
 [gofmt]: https://golang.org/cmd/gofmt/
 [goimports]: https://godoc.org/golang.org/x/tools/cmd/goimports

--- a/README.md
+++ b/README.md
@@ -1,39 +1,52 @@
 # fmt-micro
-This is a multi-language formatting plugin for the [Micro text-editor.](https://github.com/zyedidia/micro)
 
-Note that this plugin can only run installed/built-in formatters (such as `rustfmt` or `gofmt`).
+This is a multi-language formatting plugin for the
+[Micro text-editor.](https://github.com/zyedidia/micro)
+
+Note that this plugin can only run installed/built-in formatters (such as
+`rustfmt` or `gofmt`).
 
 ## Supported formatters
 
-|Formatter|Language(s)
-|:---|:---
-|[crystal tool format](https://github.com/crystal-lang/crystal)|`Crystal`
-|[fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent)|`Fish`
-|[gofmt](https://golang.org/cmd/gofmt/)|`Go`
-|[luafmt](https://github.com/trixnz/lua-fmt)|`Lua`
-|[rubocop](https://github.com/bbatsov/rubocop)|`Ruby`
-|[rustfmt](https://github.com/rust-lang-nursery/rustfmt)|`Rust`
-|[shfmt](https://github.com/mvdan/sh)|`Shell`
-|[php-cs-fixer](https://github.com/friendsofphp/PHP-CS-Fixer)|`PHP`
-|[prettier](https://github.com/prettier/prettier)|`Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown`
-|[uncrustify](https://github.com/uncrustify/uncrustify)|`C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`
-|[yapf](https://github.com/google/yapf)|`Python`
+| Formatter                                                                   | Language(s)                                                                                     |
+| :-------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| [crystal tool format](https://github.com/crystal-lang/crystal)              | `Crystal`                                                                                       |
+| [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent) | `Fish`                                                                                          |
+| [gofmt](https://golang.org/cmd/gofmt/)                                      | `Go`                                                                                            |
+| [luafmt](https://github.com/trixnz/lua-fmt)                                 | `Lua`                                                                                           |
+| [rubocop](https://github.com/bbatsov/rubocop)                               | `Ruby`                                                                                          |
+| [rustfmt](https://github.com/rust-lang-nursery/rustfmt)                     | `Rust`                                                                                          |
+| [shfmt](https://github.com/mvdan/sh)                                        | `Shell`                                                                                         |
+| [php-cs-fixer](https://github.com/friendsofphp/PHP-CS-Fixer)                | `PHP`                                                                                           |
+| [prettier](https://github.com/prettier/prettier)                            | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
+| [uncrustify](https://github.com/uncrustify/uncrustify)                      | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
+| [yapf](https://github.com/google/yapf)                                      | `Python`                                                                                        |
 
 Note that you can also get a list of formatters by running the `fmt` command.
 
 ### Installation
-1. Open your config's `settings.json` (located in `~/.config/micro/settings.json` on Linux), and add `https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json` to `pluginrepos`, like so:
-  ```json
-  "pluginrepos": [
-    "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json"
-  ],
-  ```
+
+1. Open your config's `settings.json` (located in
+   `~/.config/micro/settings.json` on Linux), and add
+   `https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json` to
+   `pluginrepos`, like so:
+
+
+```json
+"pluginrepos": [
+  "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json"
+],
+```
+
 2. Run `plugin install fmt`
 3. Restart Micro & it should work.
 
-If this plugin is added to the [official plugin channel](https://github.com/micro-editor/plugin-channel), you can skip step 1 of the installation.
+If this plugin is added to the
+[official plugin channel](https://github.com/micro-editor/plugin-channel), you
+can skip step 1 of the installation.
 
 ### Usage
-The formatter will run on-save (if enabled & exists).  
-The only command is `fmt`, which lists all of the supported formatters.  
+
+The formatter will run on-save (if enabled & exists).\
+The only command is `fmt`, which lists all of the supported formatters.\
 Run `help fmt` after installation to bring up a help file while in Micro.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ want to use.
 | [fish_indent]        | `Fish`                                                                                          |
 | [goimports], [gofmt] | `Go`                                                                                            |
 | [htmlbeautifier]     | `HTML`                                                                                          |
+| [js-beautify]        | `Javascript`                                                                                    |
 | [latexindent.pl]     | `LaTeX`                                                                                         |
 | [luafmt]             | `Lua`                                                                                           |
 | [marko-prettyprint]  | `Marko`                                                                                         |
@@ -83,6 +84,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [gofmt]: https://golang.org/cmd/gofmt/
 [goimports]: https://godoc.org/golang.org/x/tools/cmd/goimports
 [htmlbeautifier]: https://github.com/threedaymonk/htmlbeautifier
+[js-beautify]: https://github.com/beautify-web/js-beautify
 [latexindent.pl]: https://github.com/cmhughes/latexindent.pl
 [luafmt]: https://github.com/trixnz/lua-fmt
 [marko-prettyprint]: https://github.com/marko-js/marko-prettyprint

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ want to use.
 | [stylish-haskell]    | `Haskell`                                                                                       |
 | [php-cs-fixer]       | `PHP`                                                                                           |
 | [prettier]           | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
+| [puppet-lint]        | `Puppet`                                                                                        |
 | [uncrustify]         | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
 | [yapf]               | `Python`                                                                                        |
 
@@ -94,5 +95,6 @@ Run `help fmt` to bring up a help file while in Micro.
 [stylish-haskell]: https://github.com/jaspervdj/stylish-haskell
 [php-cs-fixer]: https://github.com/friendsofphp/PHP-CS-Fixer
 [prettier]: https://github.com/prettier/prettier
+[puppet-lint]: http://puppet-lint.com/
 [uncrustify]: https://github.com/uncrustify/uncrustify
 [yapf]: https://github.com/google/yapf

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ want to use.
 | [latexindent.pl]     | `LaTeX`                                                                                         |
 | [luafmt]             | `Lua`                                                                                           |
 | [marko-prettyprint]  | `Marko`                                                                                         |
+| [ocp-indent]         | `OCaml`                                                                                         |
 | [pug-beautifier-cli] | `Pug`                                                                                           |
 | [rubocop]            | `Ruby`                                                                                          |
 | [rustfmt]            | `Rust`                                                                                          |
@@ -80,6 +81,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [latexindent.pl]: https://github.com/cmhughes/latexindent.pl
 [luafmt]: https://github.com/trixnz/lua-fmt
 [marko-prettyprint]: https://github.com/marko-js/marko-prettyprint
+[ocp-indent]: https://www.typerex.org/ocp-indent.html
 [pug-beautifier-cli]: https://github.com/lgaticaq/pug-beautifier-cli
 [rubocop]: https://github.com/bbatsov/rubocop
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ want to use.
 | [crystal](https://github.com/crystal-lang/crystal)                                                          | `Crystal`                                                                                       |
 | [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent)                                 | `Fish`                                                                                          |
 | **[goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)**, [gofmt](https://golang.org/cmd/gofmt/) | `Go`                                                                                            |
+| [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier)                                            | `HTML`                                                                                          |
 | [luafmt](https://github.com/trixnz/lua-fmt)                                                                 | `Lua`                                                                                           |
 | [rubocop](https://github.com/bbatsov/rubocop)                                                               | `Ruby`                                                                                          |
 | [rustfmt](https://github.com/rust-lang-nursery/rustfmt)                                                     | `Rust`                                                                                          |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ want to use.
 | [cljfmt]             | `Clojure`                                                                                       |
 | [coffee-fmt]         | `CoffeeScript`                                                                                  |
 | [crystal]            | `Crystal`                                                                                       |
+| [CSScomb]            | `CSS`                                                                                           |
 | [elm-format]         | `Elm`                                                                                           |
 | [fish_indent]        | `Fish`                                                                                          |
 | [goimports], [gofmt] | `Go`                                                                                            |
@@ -69,6 +70,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [cljfmt]: https://github.com/snoe/node-cljfmt
 [coffee-fmt]: https://github.com/sterpe/coffee-fmt
 [crystal]: https://github.com/crystal-lang/crystal
+[csscomb]: https://github.com/csscomb/csscomb.js
 [elm-format]: https://github.com/avh4/elm-format
 [fish_indent]: https://fishshell.com/docs/current/commands.html#fish_indent
 [gofmt]: https://golang.org/cmd/gofmt/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ want to use.
 | Formatter            | Language(s)                                                                                     |
 | :------------------- | :---------------------------------------------------------------------------------------------- |
 | [align-yaml]         | `YAML`                                                                                          |
+| [autopep8]           | `Python`                                                                                        |
 | [clang-format]       | `C`, `C++`, `C#`                                                                                |
 | [cljfmt]             | `Clojure`                                                                                       |
 | [coffee-fmt]         | `CoffeeScript`                                                                                  |
@@ -74,6 +75,7 @@ Run `help fmt` to bring up a help file while in Micro.
 <!-- Table links to make the table easier to read in source -->
 
 [align-yaml]: https://github.com/jonschlinkert/align-yaml
+[autopep8]: https://github.com/hhatto/autopep8
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [cljfmt]: https://github.com/snoe/node-cljfmt
 [coffee-fmt]: https://github.com/sterpe/coffee-fmt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ want to use.
 
 | Formatter                | Language(s)                                                                                     |
 | :----------------------- | :---------------------------------------------------------------------------------------------- |
+| [cljfmt]                 | `Clojure`                                                                                       |
 | [coffee-fmt]             | `CoffeeScript`                                                                                  |
 | [crystal]                | `Crystal`                                                                                       |
 | [fish_indent]            | `Fish`                                                                                          |
@@ -60,6 +61,7 @@ Run `help fmt` to bring up a help file while in Micro.
 
 <!-- Table links to make the table easier to read in source -->
 
+[cljfmt]: https://github.com/snoe/node-cljfmt
 [coffee-fmt]: https://github.com/sterpe/coffee-fmt
 [crystal]: https://github.com/crystal-lang/crystal
 [fish_indent]: https://fishshell.com/docs/current/commands.html#fish_indent

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ want to use.
 
 ## Supported formatters
 
-| Formatter                                                                                                   | Language(s)                                                                                     |
-| :---------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| [crystal](https://github.com/crystal-lang/crystal)                                                          | `Crystal`                                                                                       |
-| [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent)                                 | `Fish`                                                                                          |
-| **[goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)**, [gofmt](https://golang.org/cmd/gofmt/) | `Go`                                                                                            |
-| [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier)                                            | `HTML`                                                                                          |
-| [luafmt](https://github.com/trixnz/lua-fmt)                                                                 | `Lua`                                                                                           |
-| [rubocop](https://github.com/bbatsov/rubocop)                                                               | `Ruby`                                                                                          |
-| [rustfmt](https://github.com/rust-lang-nursery/rustfmt)                                                     | `Rust`                                                                                          |
-| [shfmt](https://github.com/mvdan/sh)                                                                        | `Shell`                                                                                         |
-| [php-cs-fixer](https://github.com/friendsofphp/PHP-CS-Fixer)                                                | `PHP`                                                                                           |
-| [prettier](https://github.com/prettier/prettier)                                                            | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
-| [uncrustify](https://github.com/uncrustify/uncrustify)                                                      | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
-| [yapf](https://github.com/google/yapf)                                                                      | `Python`                                                                                        |
+| Formatter                | Language(s)                                                                                     |
+| :----------------------- | :---------------------------------------------------------------------------------------------- |
+| [crystal]                | `Crystal`                                                                                       |
+| [fish_indent]            | `Fish`                                                                                          |
+| **[goimports]**, [gofmt] | `Go`                                                                                            |
+| [htmlbeautifier]         | `HTML`                                                                                          |
+| [luafmt]                 | `Lua`                                                                                           |
+| [rubocop]                | `Ruby`                                                                                          |
+| [rustfmt]                | `Rust`                                                                                          |
+| [shfmt]                  | `Shell`                                                                                         |
+| [php-cs-fixer]           | `PHP`                                                                                           |
+| [prettier]               | `Javascript`, `JSX`, `Flow`, `TypeScript`, `CSS`, `Less`, `Sass`, `JSON`, `GraphQL`, `Markdown` |
+| [uncrustify]             | `C`, `C++`, `C#`, `Objective-C`, `D`, `Java`, `Pawn`, `Vala`                                    |
+| [yapf]                   | `Python`                                                                                        |
 
 Note that you can also get a list of formatters by running the `fmt` command.
 
@@ -56,3 +56,19 @@ The formatter will run on-save, unless `fmt-onsave` is false.
 * `fmt list` to output the supported formatters to Micro's log.
 
 Run `help fmt` to bring up a help file while in Micro.
+
+<!-- Table links to make the table easier to read in source -->
+
+[crystal]: https://github.com/crystal-lang/crystal
+[fish_indent]: https://fishshell.com/docs/current/commands.html#fish_indent
+[gofmt]: https://golang.org/cmd/gofmt/
+[goimports]: https://godoc.org/golang.org/x/tools/cmd/goimports
+[htmlbeautifier]: https://github.com/threedaymonk/htmlbeautifier
+[luafmt]: https://github.com/trixnz/lua-fmt
+[rubocop]: https://github.com/bbatsov/rubocop
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
+[shfmt]: https://github.com/mvdan/sh
+[php-cs-fixer]: https://github.com/friendsofphp/PHP-CS-Fixer
+[prettier]: https://github.com/prettier/prettier
+[uncrustify]: https://github.com/uncrustify/uncrustify
+[yapf]: https://github.com/google/yapf

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ want to use.
 | [htmlbeautifier]     | `HTML`                                                                                          |
 | [latexindent.pl]     | `LaTeX`                                                                                         |
 | [luafmt]             | `Lua`                                                                                           |
+| [marko-prettyprint]  | `Marko`                                                                                         |
 | [pug-beautifier-cli] | `Pug`                                                                                           |
 | [rubocop]            | `Ruby`                                                                                          |
 | [rustfmt]            | `Rust`                                                                                          |
@@ -78,6 +79,7 @@ Run `help fmt` to bring up a help file while in Micro.
 [htmlbeautifier]: https://github.com/threedaymonk/htmlbeautifier
 [latexindent.pl]: https://github.com/cmhughes/latexindent.pl
 [luafmt]: https://github.com/trixnz/lua-fmt
+[marko-prettyprint]: https://github.com/marko-js/marko-prettyprint
 [pug-beautifier-cli]: https://github.com/lgaticaq/pug-beautifier-cli
 [rubocop]: https://github.com/bbatsov/rubocop
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt

--- a/fmt.lua
+++ b/fmt.lua
@@ -110,11 +110,12 @@ local function init_table()
   insert({"c", "c++", "objective-c"}, "clang-format", "-i")
 
   -- Keep the more annoying args in a table
-  local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space"}
+  local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}
   -- Setting the non-flexible args | Seriously, why can't they be multi-purpose like these other formatters?..
   if uses_tabs == "true" then
     unruly_args["htmlbeautifier"] = "-T"
     unruly_args["coffee-fmt"] = "tab"
+    unruly_args["pug-beautifier"] = "-t " .. indent
   end
 
   insert("html", "htmlbeautifier", unruly_args["htmlbeautifier"])
@@ -123,6 +124,7 @@ local function init_table()
     "coffee-fmt",
     "--indent_style " .. unruly_args["coffee-fmt"] .. " --indent_size " .. indent .. " -i"
   )
+  insert("pug", "pug-beautifier", unruly_args["pug-beautifier"])
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -126,7 +126,8 @@ local function init_table()
     ["htmlbeautifier"] = "-t " .. indent,
     ["coffee-fmt"] = "space",
     ["pug-beautifier"] = nil,
-    ["perltidy"] = "-i=" .. indent
+    ["perltidy"] = "-i=" .. indent,
+    ["js-beautify"] = "-s " .. indent
   }
   -- Setting the non-flexible args | Seriously, why can't they be multi-purpose like these other formatters?..
   if uses_tabs == "true" then
@@ -134,6 +135,7 @@ local function init_table()
     unruly_args["coffee-fmt"] = "tab"
     unruly_args["pug-beautifier"] = "-t " .. indent
     unruly_args["perltidy"] = "-et=" .. indent
+    unruly_args["js-beautify"] = "-t"
   end
 
   insert("html", "htmlbeautifier", unruly_args["htmlbeautifier"])
@@ -144,6 +146,7 @@ local function init_table()
   )
   insert("pug", "pug-beautifier", unruly_args["pug-beautifier"])
   insert("perl", "perltidy", unruly_args["perltidy"])
+  insert("javascript", "js-beautify", unruly_args["js-beautify"] .. " -r -f")
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -120,6 +120,8 @@ local function init_table()
   insert("yaml", "align", "-p " .. indent .. " -s")
   insert("haskell", "stylish-haskell", "-i")
   insert("puppet", "puppet-lint", "--fix")
+  -- The -a arg can be used multiple times to increase aggresiveness. Unsure of what people prefer, so doing 1.
+  insert("python", "autopep8", "-a -i")
 
   -- Keep the more annoying args in a table
   local unruly_args = {

--- a/fmt.lua
+++ b/fmt.lua
@@ -108,6 +108,8 @@ local function init_table()
   -- No args from what I've found | This might need "--yes" after the filepath, unsure
   insert("elm", "elm-format", "--yes")
   insert({"c", "c++", "objective-c"}, "clang-format", "-i")
+  -- LaTeX
+  insert("tex", "latexindent.pl", "-w")
 
   -- Keep the more annoying args in a table
   local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}

--- a/fmt.lua
+++ b/fmt.lua
@@ -1,7 +1,7 @@
 VERSION = "1.3.0"
 
+-- Get user settings to use in formatter args
 function get_settings()
-  -- Get user settings to use in formatter args
   local indent_size = GetOption("tabsize") -- can't be 0
   local is_tabs = ""
   -- returns a bool
@@ -22,6 +22,7 @@ function get_settings()
   return {["indent_size"] = indent_size, ["is_tabs"] = is_tabs, ["compat_indent_size"] = compat_indent_size}
 end
 
+-- Initializes the dictionary of languages, their formatters, and the corresponding arguments
 function init_table()
   -- Dictionary of commands for easy lookup & manipulation.
   fmt_table = {}
@@ -91,8 +92,8 @@ function init_table()
   )
 end
 
+-- Declares the options to enable/disable formatter(s)
 function create_options()
-  -- Declares the table & options to enable/disable formatter(s)
   -- Avoids manually defining commands twice by reading the table
   for _, value in pairs(fmt_table) do
     -- Creates the options to enable/disable formatters individually
@@ -103,19 +104,19 @@ function create_options()
   end
 end
 
--- Only needs to run on the open of Micro
+-- Initialize the table & options when opening Micro
 function onViewOpen(view)
+  -- Only needs to run on the open of Micro
   if fmt_table == nil then
     init_table()
     create_options()
   end
 end
 
+-- Read the table to get a list of formatters for display
 function list_supported()
   local supported = {}
 
-  -- Declares the table & options to enable/disable formatter(s)
-  -- Avoids manually defining commands twice by reading the table
   for _, value in pairs(fmt_table) do
     -- Don't duplicate inserts, such as "prettier", when they support multiple filetypes.
     -- Credit to https://stackoverflow.com/a/20067270
@@ -132,9 +133,11 @@ function list_supported()
   messenger:Message("fmt's supported formatters: " .. table.concat(supported, ", ") .. ".")
 end
 
+-- Find the correct formatter, its arguments, and then run on the current file
 function format(cur_view)
+  -- Returns the literal file extension when called
   local function get_filetype()
-    -- What we'll return (assuming all goes well)
+    -- What we'll return
     local type = ""
 
     -- Iterates through the path, and captures any letters after a period
@@ -150,6 +153,7 @@ function format(cur_view)
   -- Prevent infinite loop of onSave()
   cur_view:Save(false)
 
+  -- Save filetype for checking
   local file_type = cur_view.Buf:FileType()
 
   -- Returns "Unknown" when Micro can't file the type, so we just grab the extension
@@ -157,7 +161,7 @@ function format(cur_view)
     file_type = get_filetype()
   end
 
-  -- The literal filetype name (`rust`, `shell`, etc.) is the table's key
+  -- The filetype name (`rust`, `shell`, etc.) is the table's key
   -- The literal file extension can be used when Micro can't support the filetype
   -- [1] is the cmd, [2] is args
   local target_fmt = fmt_table[file_type]

--- a/fmt.lua
+++ b/fmt.lua
@@ -104,18 +104,20 @@ local function init_table()
     "-c " .. JoinPaths(conf_path, "uncrustify") .. " --no-backup"
   )
 
-  -- If a change is made to insert() then we don't worry about any duplicated calls...
-  -- since we're just using vars for the args that change
-  local htmlbeautifier_arg = "-t " .. indent
-  local coffeefmt_arg = "space"
-
+  -- Keep the more annoying args in a table
+  local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space"}
+  -- Setting the non-flexible args | Seriously, why can't they be multi-purpose like these other formatters?..
   if uses_tabs == "true" then
-    htmlbeautifier_arg = "-T"
-    coffeefmt_arg = "tab"
+    unruly_args["htmlbeautifier"] = "-T"
+    unruly_args["coffee-fmt"] = "tab"
   end
 
-  insert("html", "htmlbeautifier", htmlbeautifier_arg)
-  insert("coffeescript", "coffee-fmt", "--indent_style " .. coffeefmt_arg .. " --indent_size " .. indent .. " -i")
+  insert("html", "htmlbeautifier", unruly_args["htmlbeautifier"])
+  insert(
+    "coffeescript",
+    "coffee-fmt",
+    "--indent_style " .. unruly_args["coffee-fmt"] .. " --indent_size " .. indent .. " -i"
+  )
   insert("clojure", "cljfmt")
 end
 

--- a/fmt.lua
+++ b/fmt.lua
@@ -110,6 +110,9 @@ local function init_table()
   insert({"c", "c++", "objective-c"}, "clang-format", "-i")
   -- LaTeX
   insert("tex", "latexindent.pl", "-w")
+  -- Unsure of the exact purpose of -t, but it's recommended when used as a tool
+  -- https://github.com/csscomb/csscomb.js/blob/dev/doc/usage-cli.md#options
+  insert("css", "csscomb", "-t")
 
   -- Keep the more annoying args in a table
   local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}

--- a/fmt.lua
+++ b/fmt.lua
@@ -115,6 +115,7 @@ local function init_table()
   insert("css", "csscomb", "-t")
   -- Seems to have some config options, but the ones we want aren't documented
   insert("marko", "marko-prettyprint")
+  insert("ocaml", "ocp-indent")
 
   -- Keep the more annoying args in a table
   local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}

--- a/fmt.lua
+++ b/fmt.lua
@@ -118,7 +118,10 @@ local function init_table()
     "coffee-fmt",
     "--indent_style " .. unruly_args["coffee-fmt"] .. " --indent_size " .. indent .. " -i"
   )
+  -- Options only available via a config file
   insert("clojure", "cljfmt")
+  -- No args from what I've found | This might need "--yes" after the filepath, unsure
+  insert("elm", "elm-format", "--yes")
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -103,6 +103,11 @@ local function init_table()
     "uncrustify",
     "-c " .. JoinPaths(conf_path, "uncrustify") .. " --no-backup"
   )
+  -- Options only available via a config file
+  insert("clojure", "cljfmt")
+  -- No args from what I've found | This might need "--yes" after the filepath, unsure
+  insert("elm", "elm-format", "--yes")
+  insert({"c", "c++", "objective-c"}, "clang-format", "-i")
 
   -- Keep the more annoying args in a table
   local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space"}
@@ -118,10 +123,6 @@ local function init_table()
     "coffee-fmt",
     "--indent_style " .. unruly_args["coffee-fmt"] .. " --indent_size " .. indent .. " -i"
   )
-  -- Options only available via a config file
-  insert("clojure", "cljfmt")
-  -- No args from what I've found | This might need "--yes" after the filepath, unsure
-  insert("elm", "elm-format", "--yes")
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -103,6 +103,16 @@ local function init_table()
     "uncrustify",
     "-c " .. JoinPaths(conf_path, "uncrustify") .. " --no-backup"
   )
+
+  -- If a change is made to insert() then we don't worry about any duplicated calls...
+  -- since we're just using vars for the args that change
+  local htmlbeautifier_arg = "-t " .. indent
+
+  if uses_tabs == "true" then
+    htmlbeautifier_arg = "-T"
+  end
+
+  insert("html", "htmlbeautifier", htmlbeautifier_arg)
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -120,12 +120,18 @@ local function init_table()
   insert("yaml", "align", "-p " .. indent .. " -s")
 
   -- Keep the more annoying args in a table
-  local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}
+  local unruly_args = {
+    ["htmlbeautifier"] = "-t " .. indent,
+    ["coffee-fmt"] = "space",
+    ["pug-beautifier"] = nil,
+    ["perltidy"] = "-i=" .. indent
+  }
   -- Setting the non-flexible args | Seriously, why can't they be multi-purpose like these other formatters?..
   if uses_tabs == "true" then
     unruly_args["htmlbeautifier"] = "-T"
     unruly_args["coffee-fmt"] = "tab"
     unruly_args["pug-beautifier"] = "-t " .. indent
+    unruly_args["perltidy"] = "-et=" .. indent
   end
 
   insert("html", "htmlbeautifier", unruly_args["htmlbeautifier"])
@@ -135,6 +141,7 @@ local function init_table()
     "--indent_style " .. unruly_args["coffee-fmt"] .. " --indent_size " .. indent .. " -i"
   )
   insert("pug", "pug-beautifier", unruly_args["pug-beautifier"])
+  insert("perl", "perltidy", unruly_args["perltidy"])
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -118,6 +118,7 @@ local function init_table()
   insert("ocaml", "ocp-indent")
   -- Overwrite is default if only source (-s) used
   insert("yaml", "align", "-p " .. indent .. " -s")
+  insert("haskell", "stylish-haskell", "-i")
 
   -- Keep the more annoying args in a table
   local unruly_args = {

--- a/fmt.lua
+++ b/fmt.lua
@@ -107,12 +107,15 @@ local function init_table()
   -- If a change is made to insert() then we don't worry about any duplicated calls...
   -- since we're just using vars for the args that change
   local htmlbeautifier_arg = "-t " .. indent
+  local coffeefmt_arg = "space"
 
   if uses_tabs == "true" then
     htmlbeautifier_arg = "-T"
+    coffeefmt_arg = "tab"
   end
 
   insert("html", "htmlbeautifier", htmlbeautifier_arg)
+  insert("coffeescript", "coffee-fmt", "--indent_style " .. coffeefmt_arg .. " --indent_size " .. indent .. " -i")
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -116,6 +116,8 @@ local function init_table()
   -- Seems to have some config options, but the ones we want aren't documented
   insert("marko", "marko-prettyprint")
   insert("ocaml", "ocp-indent")
+  -- Overwrite is default if only source (-s) used
+  insert("yaml", "align", "-p " .. indent .. " -s")
 
   -- Keep the more annoying args in a table
   local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}

--- a/fmt.lua
+++ b/fmt.lua
@@ -119,6 +119,7 @@ local function init_table()
   -- Overwrite is default if only source (-s) used
   insert("yaml", "align", "-p " .. indent .. " -s")
   insert("haskell", "stylish-haskell", "-i")
+  insert("puppet", "puppet-lint", "--fix")
 
   -- Keep the more annoying args in a table
   local unruly_args = {

--- a/fmt.lua
+++ b/fmt.lua
@@ -116,6 +116,7 @@ local function init_table()
 
   insert("html", "htmlbeautifier", htmlbeautifier_arg)
   insert("coffeescript", "coffee-fmt", "--indent_style " .. coffeefmt_arg .. " --indent_size " .. indent .. " -i")
+  insert("clojure", "cljfmt")
 end
 
 -- Declares the options to enable/disable formatter(s)

--- a/fmt.lua
+++ b/fmt.lua
@@ -113,6 +113,8 @@ local function init_table()
   -- Unsure of the exact purpose of -t, but it's recommended when used as a tool
   -- https://github.com/csscomb/csscomb.js/blob/dev/doc/usage-cli.md#options
   insert("css", "csscomb", "-t")
+  -- Seems to have some config options, but the ones we want aren't documented
+  insert("marko", "marko-prettyprint")
 
   -- Keep the more annoying args in a table
   local unruly_args = {["htmlbeautifier"] = "-t " .. indent, ["coffee-fmt"] = "space", ["pug-beautifier"] = nil}

--- a/fmt.lua
+++ b/fmt.lua
@@ -80,6 +80,7 @@ local function init_table()
   insert("ruby", "rubocop", "-f quiet -o")
   -- Doesn't have any configurable args, and forces tabs.
   insert("go", "gofmt", "-s -w")
+  insert("go", "goimports", "-w")
   -- Doesn't seem to have an actual option for tabs/spaces. stdout is default.
   insert("lua", "luafmt", "-i " .. indent .. " -w replace")
   -- Supports config files as well as cli options, unsure if this'll cause a clash.

--- a/help/fmt.md
+++ b/help/fmt.md
@@ -1,13 +1,22 @@
 # fmt plugin
-To get a list of supported formatters, run the `fmt` command, or read the `README.md`
 
-To enable the individual formatters, run `set FormatterName true`.  
-When saving a supported file-type, the plugin will automatically run on the file & save any changes.
+To get a list of supported formatters, run the `fmt` command, or read the
+`README.md`
 
-Please note that all formatters are disabled by default, as to not accidentally format your files. You must enable them individually for this plugin to do anything.
+To enable the individual formatters, run `set FormatterName true`.\
+When saving a supported file-type, the plugin will automatically run on the file
+& save any changes.
+
+Please note that all formatters are disabled by default, as to not accidentally
+format your files. You must enable them individually for this plugin to do
+anything.
 
 ## Notes for Uncrustify
-Because Uncrustify requires a config file to run, I had to bundle it with the plugin, but the name/path isn't hard-coded.
 
-If you wish to edit its config, delete `defaults.cfg` in `configs/uncrustify` and replace it with your desired `.cfg` file. The name doesn't matter.  
-Optionally, you could make a symlink to your preffered file, then any time you change your preferred config, the edits will take effect.
+Because Uncrustify requires a config file to run, I had to bundle it with the
+plugin, but the name/path isn't hard-coded.
+
+If you wish to edit its config, delete `defaults.cfg` in `configs/uncrustify`
+and replace it with your desired `.cfg` file. The name doesn't matter.\
+Optionally, you could make a symlink to your preffered file, then any time you change
+your preferred config, the edits will take effect.


### PR DESCRIPTION
Big improvements to the plugin...

- The ability to have overlapping language supporting formatters (example: multiple JS formatters), which also makes adding new formatters super safe. Note: The first one in the list gets used if "conflicting" formatters are both enabled.
- Changed from Lua's `io.popen()` to Micro's `JobStart()` for running the formatters, which should improve cross-platform support.
- Adds lots of formatters, many bringing support for new languages.
- The `fmt` command has been changed to run the formatter on the current file
- Adds the new `fmt list` command, which will print a pretty table to Micro's log that shows the current on/off status of each supported formatter.
- The `fmt-onsave` option was added to disable on-save formatting (on by default)

